### PR TITLE
Remove unused `trivial-timers` dependency

### DIFF
--- a/artilico.asd
+++ b/artilico.asd
@@ -6,7 +6,6 @@
   :license "cc nc"
   :serial t
   :depends-on (:swank
-               :trivial-timers
                :cl-opengl
                :cl-glut
                ;; :cl-glu


### PR DESCRIPTION
It does not appear to be used in Artilico, and its inclusion causes errors when attempting to load Artilico, as `trivial-timers` is not in Quicklisp.

I tried to download it using the link at https://www.cliki.net/trivial-timers , but the server that hosted it appears to be offline (and has been for at least a few weeks now).

I tried using https://github.com/cosmonaut-ok/trivial-timers but I get errors when attempting to load it.

In any case, trivial-timers does not appear to be used in Artilico, so it seems like it should be fine to remove the dependency on it.